### PR TITLE
Missing blank in description of constrainedby

### DIFF
--- a/src/topics/column1/class_definitions.tsx
+++ b/src/topics/column1/class_definitions.tsx
@@ -138,8 +138,7 @@ const constrainedbyDescription = (
         leftColumn={[<span>Replaceable component</span>, <span>Replaceable class</span>]}
         rightColumn={[
             <code className="pull-right nobreak">
-                <b>replaceable</b> <span className="typename">D</span> comp
-                <b>constrainedby</b> <span className="typename">C</span>;
+                <b>replaceable</b> <span className="typename">D</span> comp <b>constrainedby</b> <span className="typename">C</span>;
             </code>,
             <code className="pull-right nobreak">
                 <b>replaceable</b> <b>model</b> <span className="typename">M</span>


### PR DESCRIPTION
Due to a linebreak in the tsx file, there is a missing blank after "comp".
Currently it shows: `replaceable D compconstrainedby C;`.

Tried to fix it by removing the linebreak in tsx file.